### PR TITLE
Enable notebook line numbers in code settings

### DIFF
--- a/.config/Code/User/settings.json
+++ b/.config/Code/User/settings.json
@@ -82,6 +82,7 @@
       "source.organizeImports": "explicit",
     },
   },
+  "notebook.lineNumbers": "on",
   "python.analysis.autoFormatStrings": true,
   "python.analysis.autoImportCompletions": true,
   "python.analysis.completeFunctionParens": true,


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Turns on line numbers in Jupyter notebook cells in VS Code by setting `notebook.lineNumbers` to `"on"` in the user settings.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```