### PR TITLE
Add avendar and nebius ssh hosts and harden identity handling

### DIFF
--- a/.ssh/config
+++ b/.ssh/config
@@ -4,15 +4,30 @@ Host *
 	IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
 
 Host github.com
-	User git
-	HostName github.com
 	PreferredAuthentications publickey
 	IdentityFile ~/.ssh/github
+	IdentitiesOnly yes
 
 Host gitlab.com
 	PreferredAuthentications publickey
 	IdentityFile ~/.ssh/gitlab
+	IdentitiesOnly yes
+
+# Avendar
+Host runner.avendar.com
+	HostName 95.211.47.207
+	User deploy
 
 Host integrity.avendar.com
-	User deploy
 	HostName 178.162.151.210
+	User deploy
+
+Host mattermost.avendar.com
+	HostName 85.17.246.194
+	User deploy
+
+# Nebius (eu-north1)
+Host 89.169.120.* 89.169.121.* 89.169.122.* 89.169.123.*
+	User deploy
+	IdentityFile ~/.ssh/nebius
+	IdentitiesOnly yes


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Updates `~/.ssh/config` with three related changes:

- Adds `IdentitiesOnly yes` to the `github.com` and `gitlab.com` hosts so the agent only offers the matching key, and drops the redundant `User git` / `HostName github.com` entries.
- Adds Avendar hosts (`runner.avendar.com`, `mattermost.avendar.com`) and sets `User deploy` / `HostName` on `integrity.avendar.com` under an `# Avendar` comment.
- Adds a Nebius (`eu-north1`) wildcard host block for the `89.169.120.0/22` range that uses the `~/.ssh/nebius` key.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```