### PR TITLE
Update claude code settings and skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -53,7 +53,8 @@
       "Bash(gh pr create:*)",
       "Bash(gh pr merge:*)",
       "Bash(git commit:*)",
-      "Bash(git push:*)"
+      "Bash(git push:*)",
+      "Bash(git reset:*)"
     ]
   },
   "hooks": {

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -51,7 +51,9 @@ ${ARGUMENTS}
    - Run `git checkout -b <branch>`.
 
 5. Group the in-scope changes into logical commits.
-   - One purpose per commit.
+   - Prefer more, smaller commits. Group files by concern (dependencies, source, tests, deployment, tooling).
+   - One purpose per commit. If you need `and` to describe it, split it.
+   - Intermediate commits don't need to leave the repo in a working state.
    - Unrelated changes split apart even within the same file.
    - Do not stash or reorder.
    - Stage only the files that belong to each commit.

--- a/.claude/skills/pr-request/SKILL.md
+++ b/.claude/skills/pr-request/SKILL.md
@@ -80,6 +80,6 @@ ${ARGUMENTS}
 
 9. Create the PR/MR:
    - GitHub: `gh pr create --title "<title>" --body "..."`.
-   - GitLab: `glab mr create --title "<title>" --description "..." --target-branch <base>`. Check recent MRs with `glab mr list` to see whether `--remove-source-branch` or `--squash` match the project's convention.
+   - GitLab: `glab mr create --title "<title>" --description "..." --target-branch <base>`.
 
 10. Report the PR/MR URL back to the user.


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:
- Adds `git reset` to the `ask` permission list so it always prompts before running.
- Updates the commit skill to prefer more, smaller logical commits (one purpose per commit; split when you need "and" to describe it).
- Simplifies the pr-request skill by dropping the extra `glab mr list` guidance from the GitLab MR creation step.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```