### PR TITLE
Disable telemetry and enable do-not-track in shell rc files

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -58,7 +58,9 @@ fi
 eval "$(fzf --bash)"
 
 # Environment
+export DO_NOT_TRACK=true
 export EDITOR=nano
+export GH_TELEMETRY=false
 export GOPATH=$HOME/.go
 
 # Tooling

--- a/.zshrc
+++ b/.zshrc
@@ -20,7 +20,9 @@ source <(fzf --zsh)
 # Environment
 export CLICOLOR=1
 export CLICOLOR_FORCE=1
+export DO_NOT_TRACK=true
 export EDITOR=nano
+export GH_TELEMETRY=false
 export GOPATH=$HOME/.go
 
 # Tooling


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Sets `DO_NOT_TRACK=true` and `GH_TELEMETRY=false` in both `.bashrc` and `.zshrc` so any CLI honoring the [Console Do Not Track](https://consoledonottrack.com/) standard, and the GitHub CLI, skip telemetry collection by default in interactive shells.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```