### PR TITLE
Update avendar host ips and expand nebius ip ranges in ssh config

### DIFF
--- a/.ssh/config
+++ b/.ssh/config
@@ -19,15 +19,23 @@ Host runner.avendar.com
 	User deploy
 
 Host integrity.avendar.com
-	HostName 178.162.151.210
+	HostName 95.168.170.248
 	User deploy
+
+Host integrity.staging.avendar.com
+	HostName 83.149.84.221
+	User deploy
+
+Host gpu.integrity.avendar.com
+    HostName 95.168.170.249
+    User deploy
 
 Host mattermost.avendar.com
 	HostName 85.17.246.194
 	User deploy
 
 # Nebius (eu-north1)
-Host 89.169.120.* 89.169.121.* 89.169.122.* 89.169.123.*
+Host 89.169.120.* 89.169.98.* 89.169.99.* 89.169.121.* 89.169.122.* 89.169.123.*
 	User deploy
 	IdentityFile ~/.ssh/nebius
 	IdentitiesOnly yes


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

- Updates `integrity.avendar.com` to its new IP (`95.168.170.248`).
- Adds two new avendar hosts: `integrity.staging.avendar.com` and `gpu.integrity.avendar.com`.
- Expands the Nebius `eu-north1` wildcard host block to cover the `89.169.98.*` and `89.169.99.*` subnets in addition to the existing ranges.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```