### PR TITLE
Add rtk bash pretooluse hook in claude code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -91,6 +91,17 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook claude"
+          }
+        ]
+      }
     ]
   },
   "statusLine": {


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds a `PreToolUse` hook to `.claude/settings.json` that runs `rtk hook claude` on every `Bash` tool invocation, transparently rewriting commands through `rtk` (Rust Token Killer) to reduce token usage on dev operations.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```