### PR TITLE
Add claude-cloud and claude-local shell helper functions

### DIFF
--- a/.bash_functions
+++ b/.bash_functions
@@ -1,1 +1,19 @@
 #! /bin/bash
+claude-cloud() {
+    printf '\033]0;claude (cloud)\007'
+    claude "$@"
+}
+
+claude-local() {
+    if ! lms ps --json 2>/dev/null | grep -q '"modelKey":"qwen/qwen3.6-35b-a3b"'; then
+        echo "Loading qwen/qwen3.6-35b-a3b..."
+        lms load qwen/qwen3.6-35b-a3b -c 262144 -y
+    fi
+
+    printf '\033]0;claude (local)\007'
+
+    export ANTHROPIC_BASE_URL=http://localhost:1234
+    export ANTHROPIC_AUTH_TOKEN=lmstudio
+    export CLAUDE_CODE_MAX_CONTEXT_TOKENS=262144
+    claude --model qwen/qwen3.6-35b-a3b "$@"
+}

--- a/.zsh_functions
+++ b/.zsh_functions
@@ -2,3 +2,18 @@
 preexec() {
     export CMD=$1;
 }
+claude-cloud() {
+    printf '\033]0;claude (cloud)\007'
+    claude "$@"
+}
+
+claude-local() {
+    if ! lms ps --json 2>/dev/null | grep -q '"modelKey":"qwen/qwen3.6-35b-a3b"'; then
+        lms load qwen/qwen3.6-35b-a3b -c 262144 -y
+    fi
+    printf '\033]0;claude (local)\007'
+    export ANTHROPIC_BASE_URL=http://localhost:1234
+    export ANTHROPIC_AUTH_TOKEN=lmstudio
+    export CLAUDE_CODE_MAX_CONTEXT_TOKENS=262144
+    claude --model qwen/qwen3.6-35b-a3b "$@"
+}


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Add two shell helper functions to both `.bash_functions` and `.zsh_functions`:

- `claude-cloud`: Sets the terminal title to "claude (cloud)" and runs Claude normally.
- `claude-local`: Loads the `qwen/qwen3.6-35b-a3b` model via LM Studio (if not already running), sets the terminal title to "claude (local)", configures environment variables to point Claude at the local LM Studio endpoint, and runs Claude with the local model.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```