### PR TITLE
Add LM Studio bin directory to PATH in profile files

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,5 +1,6 @@
 sources=()
 paths=(
+    "$HOME/.lmstudio/bin"
     "$HOME/.local/bin"
     "$HOME/.go/bin"
     "/opt/go/bin"

--- a/.zprofile
+++ b/.zprofile
@@ -1,5 +1,6 @@
 sources=()
 paths=(
+    "$HOME/.lmstudio/bin"
     "$HOME/.local/bin"
     "$HOME/.gem/ruby/4.0.0/bin"
     "$HOME/.go/bin"


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Add `$HOME/.lmstudio/bin` to the `PATH` in both `.profile` and `.zprofile` so that the `lms` CLI is available in bash and zsh sessions.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```