### PR TITLE
Set default model to claude-opus-4-6 in claude code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -57,6 +57,7 @@
       "Bash(git reset:*)"
     ]
   },
+  "model": "claude-opus-4-6[1m]",
   "hooks": {
     "Notification": [
       {


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Set the default model to `claude-opus-4-6[1m]` in `.claude/settings.json` so Claude Code uses the Opus 4.6 model with the 1M context window by default.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```