### PR TITLE
Add go 1.21 bin directory to PATH in zprofile

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -4,6 +4,7 @@ paths=(
     "$HOME/.local/bin"
     "$HOME/.gem/ruby/4.0.0/bin"
     "$HOME/.go/bin"
+    "/opt/homebrew/opt/go@1.21/bin"
     "/opt/homebrew/opt/node@24/bin"
     "/opt/homebrew/opt/postgresql@18/bin"
     "/opt/homebrew/opt/ruby/bin"


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Add `/opt/homebrew/opt/go@1.21/bin` to the PATH in `.zprofile` so that Go 1.21 binaries installed via Homebrew are available in the shell.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```