### PR TITLE
Switch claude-local to qwen3.6-27b with reduced context window

### DIFF
--- a/.bash_functions
+++ b/.bash_functions
@@ -5,15 +5,12 @@ claude-cloud() {
 }
 
 claude-local() {
-    if ! lms ps --json 2>/dev/null | grep -q '"modelKey":"qwen/qwen3.6-35b-a3b"'; then
-        echo "Loading qwen/qwen3.6-35b-a3b..."
-        lms load qwen/qwen3.6-35b-a3b -c 262144 -y
+    if ! lms ps --json 2>/dev/null | grep -q '"modelKey":"qwen/qwen3.6-27b"'; then
+        lms load qwen/qwen3.6-27b -c 131072 -y
     fi
-
     printf '\033]0;claude (local)\007'
-
-    export ANTHROPIC_BASE_URL=http://localhost:1234
-    export ANTHROPIC_AUTH_TOKEN=lmstudio
-    export CLAUDE_CODE_MAX_CONTEXT_TOKENS=262144
-    claude --model qwen/qwen3.6-35b-a3b "$@"
+    ANTHROPIC_BASE_URL=http://localhost:1234 \
+    ANTHROPIC_AUTH_TOKEN=lmstudio \
+    CLAUDE_CODE_MAX_CONTEXT_TOKENS=131072 \
+    claude --model qwen/qwen3.6-27b "$@"
 }

--- a/.zsh_functions
+++ b/.zsh_functions
@@ -8,12 +8,12 @@ claude-cloud() {
 }
 
 claude-local() {
-    if ! lms ps --json 2>/dev/null | grep -q '"modelKey":"qwen/qwen3.6-35b-a3b"'; then
-        lms load qwen/qwen3.6-35b-a3b -c 262144 -y
+    if ! lms ps --json 2>/dev/null | grep -q '"modelKey":"qwen/qwen3.6-27b"'; then
+        lms load qwen/qwen3.6-27b -c 131072 -y
     fi
     printf '\033]0;claude (local)\007'
-    export ANTHROPIC_BASE_URL=http://localhost:1234
-    export ANTHROPIC_AUTH_TOKEN=lmstudio
-    export CLAUDE_CODE_MAX_CONTEXT_TOKENS=262144
-    claude --model qwen/qwen3.6-35b-a3b "$@"
+    ANTHROPIC_BASE_URL=http://localhost:1234 \
+    ANTHROPIC_AUTH_TOKEN=lmstudio \
+    CLAUDE_CODE_MAX_CONTEXT_TOKENS=131072 \
+    claude --model qwen/qwen3.6-27b "$@"
 }


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

- Switch local LM Studio model from `qwen3.6-35b-a3b` to `qwen3.6-27b`
- Reduce context window from 262144 to 131072 tokens
- Use inline env vars instead of `export` to avoid polluting the shell environment

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```