### PR TITLE
Add avendar direct-IP SSH hosts

### DIFF
--- a/.ssh/config
+++ b/.ssh/config
@@ -14,6 +14,18 @@ Host gitlab.com
 	IdentitiesOnly yes
 
 # Avendar
+Host 89.149.221.141 # avendar-integrity-prod-app
+	User root
+
+Host 83.149.84.221 # avendar-integrity-staging-app
+	User root
+
+Host 95.168.170.248 # avendar-shared-tooling
+	User root
+
+Host 95.168.170.249 # avendar-integrity-shared-gpu
+	User root
+
 Host analytics.avendar.com
 	HostName avendar-analytics.netbird.cloud
 	User deploy


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Adds four direct-IP `Host` entries to `.ssh/config` under the Avendar section, each connecting as `root`:
- `89.149.221.141` — avendar-integrity-prod-app
- `83.149.84.221` — avendar-integrity-staging-app
- `95.168.170.248` — avendar-shared-tooling
- `95.168.170.249` — avendar-integrity-shared-gpu

These complement the existing netbird hostname aliases by allowing direct root access to the underlying hosts by IP.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```