### PR TITLE
Enable minimalist mode in ccstatusline

### DIFF
--- a/.config/ccstatusline/settings.json
+++ b/.config/ccstatusline/settings.json
@@ -70,14 +70,14 @@
       {
         "id": "12",
         "type": "custom-text",
-        "customText": "CHR: ",
-        "color": "magenta"
+        "color": "magenta",
+        "customText": "CHR: "
       },
       {
         "id": "13",
         "type": "cache-hit-rate",
-        "rawValue": true,
-        "color": "magenta"
+        "color": "magenta",
+        "rawValue": true
       },
       {
         "id": "14",
@@ -150,7 +150,7 @@
   "inheritSeparatorColors": false,
   "globalBold": false,
   "gitCacheTtlSeconds": 5,
-  "minimalistMode": false,
+  "minimalistMode": true,
   "powerline": {
     "enabled": false,
     "separators": [


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Turns on `minimalistMode` in the ccstatusline config for a more compact status bar rendering. Also picks up a cosmetic key-order normalization (color before customText/rawValue) on the CHR widget from the formatter.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```