### PR TITLE
Set default model to claude-opus-4-8 in claude code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,7 +65,7 @@
       "Bash(glab mr merge:*)"
     ]
   },
-  "model": "claude-opus-4-6[1m]",
+  "model": "claude-opus-4-8[1m]",
   "hooks": {
     "Notification": [
       {


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Bumps the default Claude Code model in `.claude/settings.json` from `claude-opus-4-6[1m]` to `claude-opus-4-8[1m]`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```