### PR TITLE
Add reply drafting step and reply style to pr-comments skill

### DIFF
--- a/.claude/skills/pr-comments/SKILL.md
+++ b/.claude/skills/pr-comments/SKILL.md
@@ -33,7 +33,25 @@ ${ARGUMENTS}
 
 3. Go into plan mode and create a structured plan to address the comments.
 
+4. For each comment worth a reply, draft a suggested response in the reply style below and present it in the chat. Do NOT post it. Only post replies to the PR/MR if the user explicitly asks you to ("push the comments", "post the replies"); otherwise the drafts are for the user to send.
+
 ## Additional Resources
+
+### Reply Style
+
+- Be short. One to three sentences. Say the thing and stop.
+- Lead with technical substance. If a comment is wrong or incomplete, say why plainly. If the fix landed somewhere other than where the thread sits, say where.
+- Sound natural, not polished. Capitalize the first letter, but skip unnecessary polish. A trailing "changed it" is fine.
+- Avoid bot-like phrasing. No marketing tone, no em-dashes, and don't restate the reviewer's comment before answering.
+- Reference code plainly. Mention files, functions, and symbols bare. No backticks unless they're actually useful.
+
+Examples:
+
+> Done is cumulative + incremented synchronously so it's already monotonic here. The actual reorder is the concurrent chunk POSTs racing, so I guarded it in updateJob instead. Tests in jobs-update.test.ts
+
+> Changed it!
+
+> Fixed!
 
 ### Scripts
 

--- a/.claude/skills/pr-comments/SKILL.md
+++ b/.claude/skills/pr-comments/SKILL.md
@@ -39,11 +39,22 @@ ${ARGUMENTS}
 
 ### Reply Style
 
-- Be short. One to three sentences. Say the thing and stop.
-- Lead with technical substance. If a comment is wrong or incomplete, say why plainly. If the fix landed somewhere other than where the thread sits, say where.
-- Sound natural, not polished. Capitalize the first letter, but skip unnecessary polish. A trailing "changed it" is fine.
-- Avoid bot-like phrasing. No marketing tone, no em-dashes, and don't restate the reviewer's comment before answering.
-- Reference code plainly. Mention files, functions, and symbols bare. No backticks unless they're actually useful.
+- Be short.
+  - If you simply fixed something say the thing and stop.
+  - If a comment is wrong use 1 to 2 sentences.
+- Lead with technical substance:
+  - If a comment is wrong or incomplete, say why plainly.
+- Sound natural:
+  - Try to avoid jargon.
+  - Use plain english.
+  - Do not polish your reply too much.
+- Avoid bot-like phrasing:
+  - No marketing tone.
+  - No em-dashes
+  - Don't restate the reviewer's comment before answering.
+- Reference code plainly:
+  - Mention files, functions, and symbols bare.
+  - No backticks unless they're actually useful.
 
 Examples:
 


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Documentation

**What this PR does / why we need it**:

Extends the `pr-comments` skill so that after building the action plan it also drafts suggested replies for each comment worth a response, presenting them in chat rather than posting. Replies are only pushed to the PR/MR when the user explicitly asks.

Adds a Reply Style section documenting the tone and format for those drafts (short, technically substantive, natural rather than polished, no bot-like phrasing) with a few concrete examples.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```