### PR TITLE
Refine branch naming guidance in commit skill

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -46,7 +46,7 @@ ${ARGUMENTS}
    - If there are no commits yet, default to conventional commits.
 
 4. If the branch shown in the context is `main` or `master`, ask whether to create a new branch first. If yes:
-   - Infer a name from the changes. Use conventional-commit prefixes plus a short kebab-case description (e.g. `feat/add-mfa-support`).
+   - Infer a name from the changes. Pick the prefix from the conventional commit types list below that best matches the nature of the change, plus a short kebab-case description (e.g. `feat/add-mfa-support`, `fix/null-pointer-on-login`, `docs/update-readme-badge`).
    - Confirm the name with the user.
    - Run `git checkout -b <branch>`.
 


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Documentation

**What this PR does / why we need it**:

Refines the branch-naming step in the `commit` skill so it points at the conventional-commit types list already documented in the skill, rather than saying "conventional-commit prefixes" generically. Adds a couple more examples (`fix/`, `docs/`) alongside the existing `feat/` one so the guidance is clearer about picking the prefix that matches the change.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```