### PR TITLE
Add guarded shell completions and sync bash, zsh, and profile

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -55,7 +55,24 @@ if ! shopt -oq posix; then
     . /etc/bash_completion
   fi
 fi
-eval "$(fzf --bash)"
+
+command -v aws_completer > /dev/null && complete -C aws_completer aws
+command -v bun > /dev/null && source <(SHELL=bash bun completions)
+command -v codex > /dev/null && source <(codex completion bash 2>/dev/null)
+command -v dive > /dev/null && source <(dive completion bash 2>/dev/null)
+command -v fzf > /dev/null && eval "$(fzf --bash)"
+command -v gh > /dev/null && source <(gh completion -s bash 2>/dev/null)
+command -v glab > /dev/null && source <(glab completion -s bash 2>/dev/null)
+command -v mise > /dev/null && source <(mise completion bash 2>/dev/null)
+command -v ngrok > /dev/null && source <(ngrok completion 2>/dev/null)
+command -v npm > /dev/null && source <(npm completion 2>/dev/null)
+command -v packer > /dev/null && complete -o nospace -C "$(command -v packer)" packer
+command -v rustup > /dev/null && source <(rustup completions bash)
+command -v terraform > /dev/null && complete -o nospace -C "$(command -v terraform)" terraform
+command -v uv > /dev/null && source <(uv generate-shell-completion bash)
+
+[ -f /usr/lib/google-cloud-sdk/completion.bash.inc ] && source /usr/lib/google-cloud-sdk/completion.bash.inc
+[ -f "$HOME/google-cloud-sdk/completion.bash.inc" ] && source "$HOME/google-cloud-sdk/completion.bash.inc"
 
 # Environment
 export DO_NOT_TRACK=true
@@ -66,4 +83,4 @@ export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
 # Tooling
-eval "$(mise activate bash)"
+command -v mise > /dev/null && eval "$(mise activate bash)"

--- a/.profile
+++ b/.profile
@@ -1,7 +1,10 @@
 sources=()
 paths=(
+    "$HOME/.bun/bin"
+    "$HOME/.duckdb/cli/latest"
     "$HOME/.lmstudio/bin"
     "$HOME/.local/bin"
+    "$HOME/.gem/ruby/4.0.0/bin"
     "$HOME/.go/bin"
     "/opt/go/bin"
 )

--- a/.zshrc
+++ b/.zshrc
@@ -14,8 +14,23 @@ autoload bashcompinit && bashcompinit
 autoload -Uz compinit && compinit
 chmod go-w /opt/homebrew/share
 chmod -R go-w /opt/homebrew/share/zsh
-complete -C "/opt/homebrew/bin/aws_completer" aws
-source <(fzf --zsh)
+
+command -v aws_completer > /dev/null && complete -C aws_completer aws
+command -v bun > /dev/null && source <(SHELL=zsh bun completions)
+command -v codex > /dev/null && source <(codex completion zsh 2>/dev/null)
+command -v dive > /dev/null && source <(dive completion zsh 2>/dev/null)
+command -v fzf > /dev/null && source <(fzf --zsh)
+command -v gh > /dev/null && source <(gh completion -s zsh 2>/dev/null)
+command -v glab > /dev/null && source <(glab completion -s zsh 2>/dev/null)
+command -v mise > /dev/null && source <(mise completion zsh 2>/dev/null)
+command -v npm > /dev/null && source <(npm completion 2>/dev/null)
+command -v packer > /dev/null && complete -o nospace -C "$(command -v packer)" packer
+command -v rustup > /dev/null && source <(rustup completions zsh)
+command -v terraform > /dev/null && complete -o nospace -C "$(command -v terraform)" terraform
+command -v uv > /dev/null && source <(uv generate-shell-completion zsh)
+
+[ -f /opt/homebrew/share/google-cloud-sdk/completion.zsh.inc ] && source /opt/homebrew/share/google-cloud-sdk/completion.zsh.inc
+[ -f "$HOME/google-cloud-sdk/completion.zsh.inc" ] && source "$HOME/google-cloud-sdk/completion.zsh.inc"
 
 # Environment
 export CLICOLOR=1
@@ -28,4 +43,4 @@ export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
 # Tooling
-eval "$(mise activate zsh)"
+command -v mise > /dev/null && eval "$(mise activate zsh)"


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Brings the bash and zsh configs into sync and wires up shell completions for the CLI tools installed by the workstation playbook. Each completion and the `mise` activation is guarded with `command -v`, so an interactive shell no longer errors when a tool isn't installed yet. Also adds the `.bun/bin`, `.duckdb/cli/latest`, and `.gem/ruby/4.0.0/bin` entries to `.profile`.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Completions added for aws, bun, codex, dive, fzf, gh, glab, mise, ngrok, npm, packer, rustup, terraform, uv, plus the gcloud SDK completion include files. Terraform and packer use `complete -o nospace -C "$(command -v ...)"` so the completer path resolves correctly on both Linux (`/usr/bin`) and macOS (Homebrew).

**Does this PR introduce a user-facing change?**:
```release-note
Add guarded shell completions for installed CLI tools and sync the bash, zsh, and profile configs.
```
