### PR TITLE
Enable rust-analyzer lsp plugin in claude code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -121,7 +121,8 @@
   "enabledPlugins": {
     "gopls-lsp@claude-plugins-official": true,
     "pyright-lsp@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true
+    "typescript-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true
   },
   "alwaysThinkingEnabled": true,
   "voiceEnabled": true


### PR DESCRIPTION
**What type of PR is this?**
- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Documentation

**What this PR does / why we need it**:

Enables the `rust-analyzer-lsp` plugin in the Claude Code settings, alongside the existing gopls, pyright, and typescript LSP plugins, so Rust projects get language-server support. Also adds a trailing newline at the end of the file.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Enable the rust-analyzer LSP plugin in Claude Code settings.
```
