### PR TITLE
Add rustup bin directory to PATH in zprofile

### DIFF
--- a/.zprofile
+++ b/.zprofile
@@ -8,6 +8,7 @@ paths=(
     "/opt/homebrew/opt/node@24/bin"
     "/opt/homebrew/opt/postgresql@18/bin"
     "/opt/homebrew/opt/ruby/bin"
+    "/opt/homebrew/opt/rustup/bin"
     "/opt/homebrew/bin"
     "/opt/homebrew/sbin"
 )


### PR DESCRIPTION
**What type of PR is this?**
- [x] Enhancement (new features, refinement)

**What this PR does / why we need it**:

Adds `/opt/homebrew/opt/rustup/bin` to the PATH in `.zprofile` so the rustup-managed toolchain shims (rustc, cargo, etc.) are available on the shell path.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```