### PR TITLE
Ban engineering jargon in pr-comments reply style

### DIFF
--- a/.claude/skills/pr-comments/SKILL.md
+++ b/.claude/skills/pr-comments/SKILL.md
@@ -44,9 +44,8 @@ ${ARGUMENTS}
   - If a comment is wrong use 1 to 2 sentences.
 - Lead with technical substance:
   - If a comment is wrong or incomplete, say why plainly.
-- Sound natural:
-  - Try to avoid jargon.
-  - Use plain english.
+- Sound natural, no engineering jargon:
+  - If a reviewer might have to look a word up, use plain words instead.
   - Do not polish your reply too much.
 - Avoid bot-like phrasing:
   - No marketing tone.
@@ -58,7 +57,7 @@ ${ARGUMENTS}
 
 Examples:
 
-> Done is cumulative + incremented synchronously so it's already monotonic here. The actual reorder is the concurrent chunk POSTs racing, so I guarded it in updateJob instead. Tests in jobs-update.test.ts
+> Done only ever counts up here since it's incremented in order, so it can't go backwards. The real reorder is the concurrent chunk POSTs racing, so I guarded it in updateJob instead.
 
 > Changed it!
 

--- a/.claude/skills/pr-comments/SKILL.md
+++ b/.claude/skills/pr-comments/SKILL.md
@@ -57,7 +57,7 @@ ${ARGUMENTS}
 
 Examples:
 
-> Done only ever counts up here since it's incremented in order, so it can't go backwards. The real reorder is the concurrent chunk POSTs racing, so I guarded it in updateJob instead.
+> Only ever counts up here since it's incremented in order, so it can't go backwards.
 
 > Changed it!
 


### PR DESCRIPTION
**What type of PR is this?**
- [x] Documentation

**What this PR does / why we need it**:

Tightens the reply-style guidance in the pr-comments skill so replies stay readable for the reviewer:

- Replaces the soft "try to avoid jargon" rule with a firm "no engineering jargon", using the test of whether a reviewer would have to look a word up.
- Rewrites the example reply that leaned on "monotonic" into plain english that says the same thing (the count only ever goes up, so it can't go backwards).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```